### PR TITLE
Don't crash on comments without 'attributes' field

### DIFF
--- a/cws2atom.py
+++ b/cws2atom.py
@@ -71,7 +71,7 @@ def get_comment_replies(extension_id, comment_list, num_results=100):
     id_to_index = dict()
     
     for comment in comment_list:
-        if "replyExists" in comment["attributes"] and comment["attributes"]["replyExists"] is True:
+        if "attributes" in comment and "replyExists" in comment["attributes"] and comment["attributes"]["replyExists"] is True:
             search_query = copy.deepcopy(search_query_template)
             search_query["entities"][0]["annotation"]["author"] = comment["entity"]["author"]
             search_query["entities"][0]["annotation"]["groups"] = comment["entity"]["groups"]
@@ -90,7 +90,7 @@ def get_all_webstore_data(extension_id, num_results):
     comment_replies = get_comment_replies(extension_id, comment_list)
     comments_with_replies_count = 0
     for comment in comment_list:
-        if comment["attributes"].get("replyExists", False) is True and comment_replies["searchResults"][comments_with_replies_count]["numAnnotations"] > 0:
+        if comment.get("attributes", {}).get("replyExists", False) is True and comment_replies["searchResults"][comments_with_replies_count]["numAnnotations"] > 0:
             comment["cws2atom_replies"] = comment_replies["searchResults"][comments_with_replies_count]["annotations"]
             comments_with_replies_count += 1
     return comment_list


### PR DESCRIPTION
Hi! I've been running cws2atom everyday for the last 5 months, so many thanks for this!

Yesterday a new comment was posted on my extension and since then cws2atom started to fail with:

```
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title type="text">CWS: gjhnbhjegnfhehpjhkajgfbkcbpmomoh</title>
  <id>https://chrome.google.com/webstore/detail/gjhnbhjegnfhehpjhkajgfbkcbpmomoh</id>
  <updated>2018-08-31T12:47:17Z</updated>
  <link href="https://chrome.google.com/webstore/detail/gjhnbhjegnfhehpjhkajgfbkcbpmomoh" />
  <link href="https://chrome.google.com/webstore/detail/gjhnbhjegnfhehpjhkajgfbkcbpmomoh" rel="self" />
  <subtitle type="text">Feed for reviews and support issues</subtitle>
  <generator>PyAtom</generator>
  <entry xml:base="https://chrome.google.com/webstore/detail/gjhnbhjegnfhehpjhkajgfbkcbpmomoh">
    <title type="text">Exception has occured!</title>
    <id>2018-08-31 12:47:17.679670</id>
    <updated>2018-08-31T12:47:17Z</updated>
    <author>
      <name></name>
    </author>
    <content type="html">&lt;p&gt;Traceback (most recent call last):
&lt;br /&gt;  File "cws2atom.py", line 126, in &lt;module&gt;
    comments_with_replies_list = get_all_webstore_data(extension_id, num_results)
&lt;br /&gt;  File "cws2atom.py", line 90, in get_all_webstore_data
    comment_replies = get_comment_replies(extension_id, comment_list)
&lt;br /&gt;  File "cws2atom.py", line 74, in get_comment_replies
    if "replyExists" in comment["attributes"] and comment["attributes"]["replyExists"] is True:
&lt;br /&gt;KeyError: 'attributes'
&lt;/p&gt;</content>
  </entry>
</feed>
```

In the web UI there is nothing special with that comment but indeed for some reasons it has no `attributes` field:

```
{
  'formattedTimeString': 'Modified 22 hours ago',
  'language': 'en',
  'labels': [],
  'comment': 'nice application',
  'labelsWeightPercent': [],
  'creationTimestamp': 1535639912,
  'secondaryEntity': [],
  'entity': {
    'groups': ['chrome_webstore'],
    'shortAuthor': '112773441430467500597',
    'author': 'AIe9_BFloMqPmnteU-b8RP9o__ZERbURy102R1zHvGmJRHoLECjvXhWOhy0uJ14y_IqwuP-OU1Yu',
    'displayName': 'Amol Thorat',
    'authorPhotoUrl': '//plus.google.com/_/focus/photos/public/AIbEiAIAAABECLSasvX_2pbPywEiC3ZjYXJkX3Bob3RvKigxOGQxOGE5ZTRjMDgxOTU2ZGI1ZWJkM2FjMTAyNDE1MmE2MWExYTkzMAE9uzqz_0cU6kOwkXIbZIjiLRYS7A',
    'url': 'http://chrome.google.com/extensions/permalink?id=gjhnbhjegnfhehpjhkajgfbkcbpmomoh',
    'profileUrl': 'https://plus.google.com/114672264519756844340'
  },
  'starRating': 5,
  'timestamp': 1535639929
}
```

So in this pull request I'm simply making cws2atom tolerate comments with no `attributes` field. Thanks!
